### PR TITLE
Message#deleted to Message#deletable

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Defaults to:
 
 ```js
 ({ newIdentifiers, currentIdentifiers, paginator }) =>
-		!paginator.message.deleted && newIdentifiers.pageIdentifier !== currentIdentifiers.pageIdentifier,
+		paginator.message.deletable && newIdentifiers.pageIdentifier !== currentIdentifiers.pageIdentifier,
 ```
 
 ### footerResolver

--- a/example/src/util/Constants.js
+++ b/example/src/util/Constants.js
@@ -17,7 +17,7 @@ module.exports.basicEndHandler = async ({ reason, paginator }) => {
   // This is a basic handler that will delete the message containing the pagination.
   try {
     console.log(`The pagination has ended: ${reason}`);
-    if (!paginator.message.deleted) await paginator.message.delete();
+    if (paginator.message.deletable) await paginator.message.delete();
   } catch (error) {
     console.log('There was an error when deleting the message: ');
     console.log(error);

--- a/src/structures/BasePaginator.js
+++ b/src/structures/BasePaginator.js
@@ -165,7 +165,7 @@ class BasePaginator extends EventEmitter {
         paginator: this,
       };
       // Guard against a message deletion in the page resolver.
-      if (!this.message.deleted) {
+      if (this.message.deletable) {
         await this.changePage(changePageArgs);
         await this._collectEnd(collectorArgs);
       }

--- a/src/util/BaseOptions.js
+++ b/src/util/BaseOptions.js
@@ -7,7 +7,7 @@ class BaseOptions extends null {
       messageSender: ({ interaction, messageOptions }) => interaction.editReply(messageOptions),
       initialIdentifiers: { pageIdentifier: 0 },
       shouldChangePage: ({ newIdentifiers, currentIdentifiers, paginator }) =>
-        !paginator.message.deleted && newIdentifiers.pageIdentifier !== currentIdentifiers.pageIdentifier,
+        paginator.message.deletable && newIdentifiers.pageIdentifier !== currentIdentifiers.pageIdentifier,
       useCache: true,
       collectorOptions: {
         filter: ({ interaction, paginator }) => interaction.user === paginator.user && !interaction.user.bot,


### PR DESCRIPTION
Changed Message#deleted property to Message#deletable. Discord.js will remove .deleted in next major version & it's currently deprecated in main branch. 


See: https://github.com/discordjs/discord.js/issues/7091